### PR TITLE
Changed Community.Lawyer to Afterpattern, everywhere but the classes

### DIFF
--- a/class/docs/introduction-to-docassemble.md
+++ b/class/docs/introduction-to-docassemble.md
@@ -34,7 +34,7 @@ Notable apps in the same space but with different functionality include:
 
 1. [QnAMarkup](https://qnamarkup.org)
 
-Docassemble has also inspired two user-friendly low-code frontends: [Community.Lawyer](https://community.lawyer) and [Documate](https://www.documate.org/).
+Docassemble has also inspired two user-friendly low-code frontends: [Afterpattern](https://afterpattern.com/) (previously Community Lawyer) and [Documate](https://www.documate.org/).
 
 ## How does Docassemble work?
 

--- a/class/docs/legal-tech-overview/examples.md
+++ b/class/docs/legal-tech-overview/examples.md
@@ -48,7 +48,7 @@ Think of this as a curated walkthrough of some popular legal technology tools.
   built on Python with strong customizability and expert system capabilities
     * [Documate](https://documate.org), a frontend for Docassemble that exposes
       most of its power
-    * [Community.Lawyer](https://community.lawyer), a frontend for Docassemble
+    * [Afterpattern](https://afterpattern.com/), a frontend for Docassemble
       with a free tier + marketplace
 * [A2JAuthor.org](https://a2jauthor.org), a popular non-commercial frontend to
   HotDocs which also includes limited document assembly capabilities that don't

--- a/class/docs/legal-tech-overview/legal-tech-overview.md
+++ b/class/docs/legal-tech-overview/legal-tech-overview.md
@@ -155,7 +155,7 @@ services to clients.
   databases, often run by bar associations or legal aid agencies)
 * Lawyer rating and matching services, like Avvo or pro bono focused ones like Paladin
 * Marketplace tools that allow lawyers to sell legal services.
-* Legal App marketplaces, like those created by Community.Lawyer and HotDocs
+* Legal App marketplaces, like those created by Afterpattern and HotDocs
 
 ### Technology used by courts
 

--- a/class/docs/practical-guide-docassemble/practical-guide-docassemble.md
+++ b/class/docs/practical-guide-docassemble/practical-guide-docassemble.md
@@ -101,4 +101,4 @@ Docassemble's built-in features could easily be dedicated tools in their own rig
 
 ## Other lists of apps built with Docassemble
 
-* https://community.lawyer/featured-apps
+* https://afterpattern.com/search


### PR DESCRIPTION
Update references to Community.Lawyer to Afterpattern, with all of the link redirects as well. Didn't change references in class specific pages.